### PR TITLE
Fix typo in comment: "mush" → "must"

### DIFF
--- a/parser/src/main/kotlin/com/zaneschepke/wireguardautotunnel/parser/util/NetworkUtils.kt
+++ b/parser/src/main/kotlin/com/zaneschepke/wireguardautotunnel/parser/util/NetworkUtils.kt
@@ -85,7 +85,7 @@ object NetworkUtils {
 
         var index = 0
 
-        // every tag mush start with <
+        // every tag must start with <
         while (index < value.length) {
             if (value[index] != '<') {
                 throw ConfigParseException(ErrorType.INVALID_SIGNATURE_FORMAT, fieldName, value)


### PR DESCRIPTION
## Summary
- Fix `"every tag mush start with"` → `"every tag must start with"` in `parser/src/main/kotlin/.../NetworkUtils.kt`

Single-character fix in a code comment.